### PR TITLE
Fix Portuguese text in password validator

### DIFF
--- a/Account/Register.aspx
+++ b/Account/Register.aspx
@@ -60,7 +60,7 @@
                         TextMode="Password" CssClass="form-control" />
                     <asp:RequiredFieldValidator runat="server"
                         ControlToValidate="txtPassword"
-                        ErrorMessage="A password é obrigatória."
+                        ErrorMessage="A palavra-passe é obrigatória."
                         CssClass="invalid-feedback d-block" />
                 </div>
 


### PR DESCRIPTION
## Summary
- update Register page text for password RequiredFieldValidator

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-6.0` *(fails: no installation candidate)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_683f6f847078832898eb3ee976d873dd