### PR TITLE
Add CountryList caching tests

### DIFF
--- a/Tests/TrabalhoFinal3.Tests/CountryListTests.cs
+++ b/Tests/TrabalhoFinal3.Tests/CountryListTests.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TrabalhoFinal3.Data;
+
+namespace TrabalhoFinal3.Tests
+{
+    [TestClass]
+    public class CountryListTests
+    {
+        private string GetJsonPath()
+        {
+            var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            return Path.Combine(baseDir, "TestResources", "countries.json");
+        }
+
+        [TestInitialize]
+        public void Init()
+        {
+            var field = typeof(CountryList).GetField("_cache", BindingFlags.NonPublic | BindingFlags.Static);
+            field.SetValue(null, null);
+        }
+
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public void All_ShouldDeserializeJsonFile()
+        {
+            var path = GetJsonPath();
+            var countries = CountryList.All(path);
+            Assert.AreEqual(2, countries.Count);
+            Assert.AreEqual("US", countries[0].Code);
+            Assert.AreEqual("United States", countries[0].Name);
+        }
+
+        [TestMethod]
+        public void All_ShouldReturnCachedInstance_OnSubsequentCalls()
+        {
+            var path = GetJsonPath();
+            var first = CountryList.All(path);
+            var second = CountryList.All(path);
+            Assert.AreSame(first, second);
+        }
+    }
+}

--- a/Tests/TrabalhoFinal3.Tests/TestResources/countries.json
+++ b/Tests/TrabalhoFinal3.Tests/TestResources/countries.json
@@ -1,0 +1,4 @@
+[
+  { "Code": "US", "Name": "United States" },
+  { "Code": "BR", "Name": "Brazil" }
+]

--- a/Tests/TrabalhoFinal3.Tests/TrabalhoFinal3.Tests.csproj
+++ b/Tests/TrabalhoFinal3.Tests/TrabalhoFinal3.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="TestResources\countries.json"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
+    <ProjectReference Include="..\..\TrabalhoFinal3.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.0" />
+  </ItemGroup>
+</Project>

--- a/TrabalhoFinal3.sln
+++ b/TrabalhoFinal3.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36127.28 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrabalhoFinal3", "TrabalhoFinal3.csproj", "{6C618124-8BF6-487A-8731-E8972DB61CD6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrabalhoFinal3.Tests", "Tests\TrabalhoFinal3.Tests\TrabalhoFinal3.Tests.csproj", "{c8581386-80e7-47f8-a4f9-db0282a5f0ac}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{6C618124-8BF6-487A-8731-E8972DB61CD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C618124-8BF6-487A-8731-E8972DB61CD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6C618124-8BF6-487A-8731-E8972DB61CD6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {c8581386-80e7-47f8-a4f9-db0282a5f0ac}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {c8581386-80e7-47f8-a4f9-db0282a5f0ac}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {c8581386-80e7-47f8-a4f9-db0282a5f0ac}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {c8581386-80e7-47f8-a4f9-db0282a5f0ac}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- introduce MSTest-based test project
- add CountryList tests verifying deserialization and caching
- include test JSON resource
- update solution file with the new test project

## Testing
- `dotnet test TrabalhoFinal3.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6f8f417083289a0a2a0ad60301f1