### PR TITLE
Allow profile to load by id

### DIFF
--- a/Account/Profile.aspx.cs
+++ b/Account/Profile.aspx.cs
@@ -15,6 +15,13 @@ namespace TrabalhoFinal3.Account
     {
         private readonly UserService _svc = new UserService();
 
+        private User GetRequestedUser()
+        {
+            if (int.TryParse(Request.QueryString["userId"], out int uid))
+                return _svc.GetUser(uid);
+            return _svc.GetUser(Page.User.Identity.Name);
+        }
+
         protected void Page_Load(object sender, EventArgs e)
         {
             if (!Page.User.Identity.IsAuthenticated)
@@ -34,7 +41,7 @@ namespace TrabalhoFinal3.Account
 
         private void LoadData()
         {
-            var user = _svc.GetUser(Page.User.Identity.Name);
+            var user = GetRequestedUser();
             if (user == null) return;
 
             if (string.Equals(user.RoleName, "Administrador", StringComparison.OrdinalIgnoreCase))
@@ -93,7 +100,7 @@ namespace TrabalhoFinal3.Account
         {
             if (!Page.IsValid) return;
 
-            var user = _svc.GetUser(Page.User.Identity.Name);
+            var user = GetRequestedUser();
             if (user == null) return;
 
             user.FirstName = TxtFirstName.Text;
@@ -116,7 +123,9 @@ namespace TrabalhoFinal3.Account
         protected void BtnReset_Click(object sender, EventArgs e) => LoadData();
         protected void BtnDelete_Click(object sender, EventArgs e)
         {
-            _svc.DeleteAccount(Page.User.Identity.Name);
+            var user = GetRequestedUser();
+            if (user == null) return;
+            _svc.DeleteAccount(user.Email);
             FormsAuthentication.SignOut();
             Response.Redirect("~/Account/Login.aspx");
         }
@@ -128,7 +137,9 @@ namespace TrabalhoFinal3.Account
             string path = "~/Uploads/Avatars/" + filename;
             FupAvatar.SaveAs(Server.MapPath(path));
 
-            _svc.UpdateUserPhoto(Page.User.Identity.Name, path);
+            var user = GetRequestedUser();
+            if (user == null) return;
+            _svc.UpdateUserPhoto(user.Email, path);
             ImgAvatar.ImageUrl = path;
         }
 
@@ -153,14 +164,14 @@ namespace TrabalhoFinal3.Account
             DdlCountry.Items.Insert(0, new ListItem("Escolher país", ""));
 
             // Pré-seleccionar valor guardado
-            var user = new UserService().GetUser(Page.User.Identity.Name);
+            var user = GetRequestedUser();
             if (user != null && !string.IsNullOrEmpty(user.Country))
                 DdlCountry.SelectedValue = user.Country;
         }
 
         protected void LnkResend_Click(object sender, EventArgs e)
         {
-            var user = new UserService().GetUser(Page.User.Identity.Name);
+            var user = GetRequestedUser();
             if (user == null) return;
 
             // gerar token / link de verificação

--- a/Models/UserService.cs
+++ b/Models/UserService.cs
@@ -80,6 +80,54 @@ public class UserService
         }
     }
 
+    public User GetUser(int id)
+    {
+        const string sql =
+                "SELECT U.USER_ID, U.USER_EMAIL, U.USER_PASSWORD, " +
+                "       U.ROLE_ID, U.STATUS_ID, U.USER_FIRST_NAME, U.USER_LAST_NAME, U.USER_TITLE, U.USER_BIOGRAPHY, U.USER_PROFILE_PICTURE_URL, " +
+                "       U.USER_PHONE_NUMBER, U.USER_ADDRESS, U.USER_CITY, U.USER_COUNTRY, " +
+                "       U.USER_LANGUAGE, U.USER_TIMEZONE, U.USER_NOTIFICATION_PREFERENCES," +
+                "       R.ROLE_NAME, S.STATUS_NAME " +
+                "FROM   sc24_197.[USER]               U " +
+                "LEFT  JOIN sc24_197.[USERROLE]       R ON U.ROLE_ID   = R.ROLE_ID " +
+                "LEFT  JOIN sc24_197.[USER_STATUS]    S ON U.STATUS_ID = S.STATUS_ID " +
+                "WHERE  U.USER_ID = @Id";
+
+        using (SqlConnection conn = new SqlConnection(connStr))
+        using (SqlCommand cmd = new SqlCommand(sql, conn))
+        {
+            cmd.Parameters.AddWithValue("@Id", id);
+
+            conn.Open();
+            var dr = cmd.ExecuteReader(CommandBehavior.SingleRow);
+
+            if (!dr.Read()) return null;
+
+            return new User
+            {
+                UserId = dr.GetInt32(0),
+                Email = dr.GetString(1),
+                Password = dr.GetString(2),
+                UserRoleId = dr.GetInt32(3),
+                UserStatusId = dr.GetInt32(4),
+                FirstName = dr.GetString(5),
+                LastName = dr.GetString(6),
+                Title = dr.IsDBNull(7) ? null : dr.GetString(7),
+                Bio = dr.IsDBNull(8) ? null : dr.GetString(8),
+                PhotoPath = dr.IsDBNull(9) ? null : dr.GetString(9),
+                Phone = dr.IsDBNull(10) ? null : dr.GetString(10),
+                Address = dr.IsDBNull(11) ? null : dr.GetString(11),
+                City = dr.IsDBNull(12) ? null : dr.GetString(12),
+                Country = dr.IsDBNull(13) ? null : dr.GetString(13),
+                Language = dr.IsDBNull(14) ? null : dr.GetString(14),
+                TimeZone = dr.IsDBNull(15) ? null : dr.GetString(15),
+                NotifyOptions = dr.IsDBNull(16) ? null : dr.GetString(16),
+                RoleName = dr.IsDBNull(17) ? null : dr.GetString(17),
+                StatusName = dr.IsDBNull(18) ? null : dr.GetString(18)
+            };
+        }
+    }
+
     public void UpdateUser(User u)
     {
         const string sql =

--- a/Views/Admin/AdminUsers.aspx
+++ b/Views/Admin/AdminUsers.aspx
@@ -14,7 +14,7 @@
             <asp:BoundField DataField="RoleName" HeaderText="Perfil" />
             <asp:TemplateField HeaderText="Ações">
                 <ItemTemplate>
-                    <asp:Button ID="btnVerPerfil" runat="server" Text="Ver Perfil" CommandName="VerPerfil" CommandArgument='<%# Eval("UserId") %>' CssClass="btn btn-outline-primary btn-sm" />
+                    <asp:HyperLink ID="lnkVerPerfil" runat="server" Text="Ver Perfil" NavigateUrl='<%# "~/Account/Profile.aspx?userId=" + Eval("UserId") %>' CssClass="btn btn-outline-primary btn-sm" />
                     <asp:Button ID="btnApagar" runat="server" Text="Apagar" CommandName="Apagar" CommandArgument='<%# Eval("UserId") %>' CssClass="btn btn-outline-danger btn-sm" OnClientClick="return confirm('Tem a certeza que deseja apagar este utilizador?');" />
                 </ItemTemplate>
             </asp:TemplateField>

--- a/Views/Admin/AdminUsers.aspx.cs
+++ b/Views/Admin/AdminUsers.aspx.cs
@@ -33,11 +33,7 @@ namespace TrabalhoFinal3
         {
             int id = Convert.ToInt32(e.CommandArgument);
 
-            if (e.CommandName == "VerPerfil")
-            {
-                Response.Redirect($"PerfilUtilizador.aspx?id={id}");
-            }
-            else if (e.CommandName == "Apagar")
+            if (e.CommandName == "Apagar")
             {
                 ApagarUser(id);
                 CarregarUtilizadores();


### PR DESCRIPTION
## Summary
- add `GetUser(int id)` to `UserService` for fetching a user by identifier
- update `Profile.aspx.cs` to load requested user via query string and use that user in actions
- link each AdminUsers entry directly to profile using `NavigateUrl`

## Testing
- `dotnet test` *(fails: Microsoft.WebApplication.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f7bdd5ebc8328a690749a5f9aca3b