### PR TITLE
Prevent duplicate areas in backoffice

### DIFF
--- a/Views/Admin/Backoffice.aspx
+++ b/Views/Admin/Backoffice.aspx
@@ -20,6 +20,7 @@
         <asp:DropDownList ID="ddlAreaCategory" runat="server" CssClass="form-select mb-1" />
         <asp:TextBox ID="txtNewArea" runat="server" CssClass="form-control mb-1" Placeholder="Nova area" />
         <asp:Button ID="btnAddArea" runat="server" Text="Adicionar" CssClass="btn btn-primary" OnClick="btnAddArea_Click" />
+        <asp:Label ID="lblAreaMessage" runat="server" CssClass="text-danger d-block mt-1" />
     </div>
     <asp:GridView ID="gvAreas" runat="server" AutoGenerateColumns="False" AutoGenerateEditButton="True" DataKeyNames="AREA_ID" CssClass="table table-bordered mb-4" OnRowEditing="gvAreas_RowEditing" OnRowUpdating="gvAreas_RowUpdating" OnRowCancelingEdit="gvAreas_RowCancelingEdit">
         <Columns>

--- a/Views/Admin/Backoffice.aspx.cs
+++ b/Views/Admin/Backoffice.aspx.cs
@@ -113,6 +113,18 @@ namespace TrabalhoFinal3
             }
         }
 
+        private bool AreaExists(int? id, string name)
+        {
+            using (SqlConnection cn = new SqlConnection(cs))
+            using (SqlCommand cmd = new SqlCommand("SELECT dbo.fn_CheckAreaExixts(@id, @n)", cn))
+            {
+                cmd.Parameters.AddWithValue("@id", (object?)id ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("@n", (object?)name ?? DBNull.Value);
+                cn.Open();
+                return Convert.ToInt32(cmd.ExecuteScalar()) > 0;
+            }
+        }
+
         protected void btnAddCategory_Click(object sender, EventArgs e)
         {
             using (SqlConnection cn = new SqlConnection(cs))
@@ -156,16 +168,26 @@ namespace TrabalhoFinal3
 
         protected void btnAddArea_Click(object sender, EventArgs e)
         {
+            lblAreaMessage.Text = string.Empty;
+            string name = txtNewArea.Text.Trim();
+            if (AreaExists(null, name))
+            {
+                lblAreaMessage.Text = "Área já existe";
+                return;
+            }
+
             using (SqlConnection cn = new SqlConnection(cs))
             using (SqlCommand cmd = new SqlCommand("INSERT INTO sc24_197.COURSE_AREA (AREA_NAME, CATEGORY_ID) VALUES (@n, @c)", cn))
             {
-                cmd.Parameters.AddWithValue("@n", txtNewArea.Text.Trim());
+                cmd.Parameters.AddWithValue("@n", name);
                 cmd.Parameters.AddWithValue("@c", ddlAreaCategory.SelectedValue);
                 cn.Open();
                 cmd.ExecuteNonQuery();
             }
             txtNewArea.Text = string.Empty;
             LoadAreas();
+            lblAreaMessage.CssClass = "text-success";
+            lblAreaMessage.Text = "Área adicionada com sucesso";
         }
 
         protected void gvAreas_RowEditing(object sender, GridViewEditEventArgs e)
@@ -184,6 +206,13 @@ namespace TrabalhoFinal3
         {
             int id = (int)gvAreas.DataKeys[e.RowIndex].Value;
             string name = ((TextBox)gvAreas.Rows[e.RowIndex].Cells[1].Controls[0]).Text;
+            lblAreaMessage.Text = string.Empty;
+            if (AreaExists(id, name))
+            {
+                lblAreaMessage.Text = "Área já existe";
+                return;
+            }
+
             using (SqlConnection cn = new SqlConnection(cs))
             using (SqlCommand cmd = new SqlCommand("UPDATE sc24_197.COURSE_AREA SET AREA_NAME=@n WHERE AREA_ID=@id", cn))
             {
@@ -194,6 +223,8 @@ namespace TrabalhoFinal3
             }
             gvAreas.EditIndex = -1;
             LoadAreas();
+            lblAreaMessage.CssClass = "text-success";
+            lblAreaMessage.Text = "Área atualizada com sucesso";
         }
 
         protected void btnAddTopic_Click(object sender, EventArgs e)

--- a/Views/Admin/Backoffice.aspx.designer.cs
+++ b/Views/Admin/Backoffice.aspx.designer.cs
@@ -69,6 +69,15 @@ namespace TrabalhoFinal3
         protected global::System.Web.UI.WebControls.Button btnAddArea;
 
         /// <summary>
+        /// lblAreaMessage control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblAreaMessage;
+
+        /// <summary>
         /// gvAreas control.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Summary
- prevent duplicate areas when adding or editing on the Backoffice page
- show messages when an area is added or updated successfully
- expose new label control for area messages

## Testing
- `dotnet build TrabalhoFinal3.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401db64cd083288a79600b0075b251